### PR TITLE
Fix/falha de seguranca atualizar deletar usuario

### DIFF
--- a/src/main/java/br/com/zup/projeto_final/Usuario/UsuarioController.java
+++ b/src/main/java/br/com/zup/projeto_final/Usuario/UsuarioController.java
@@ -2,6 +2,7 @@ package br.com.zup.projeto_final.Usuario;
 import br.com.zup.projeto_final.Usuario.dto.UsuarioDTO;
 import br.com.zup.projeto_final.Usuario.dto.UsuarioSaidaDTO;
 import br.com.zup.projeto_final.seguranca.UsuarioLogado;
+import br.com.zup.projeto_final.usuarioLogado.UsuarioLogadoService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,8 @@ public class UsuarioController {
     UsuarioService usuarioService;
     @Autowired
     ModelMapper modelMapper;
+    @Autowired
+    UsuarioLogadoService usuarioLogadoService;
 
 
     @PostMapping
@@ -52,10 +55,11 @@ public class UsuarioController {
 
     }
 
-    @PutMapping("/{id}")
+    @PutMapping
     @ResponseStatus(HttpStatus.OK)
-    public UsuarioSaidaDTO atualizarUsuario(@PathVariable String id, @RequestBody UsuarioDTO usuarioDTO) throws Exception {
-        Usuario usuario = usuarioService.atualizarUsuario(id, modelMapper.map(usuarioDTO, Usuario.class));
+    public UsuarioSaidaDTO atualizarUsuario(@RequestBody UsuarioDTO usuarioDTO){
+        Usuario usuario = usuarioService.atualizarUsuario(usuarioLogadoService.pegarId(),
+                modelMapper.map(usuarioDTO, Usuario.class));
 
 
         return modelMapper.map(usuario, UsuarioSaidaDTO.class);

--- a/src/main/java/br/com/zup/projeto_final/Usuario/UsuarioController.java
+++ b/src/main/java/br/com/zup/projeto_final/Usuario/UsuarioController.java
@@ -66,10 +66,10 @@ public class UsuarioController {
 
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deletarUsuario(@PathVariable String id) {
-        usuarioService.deletarusuario(id);
+    public void deletarUsuario() {
+        usuarioService.deletarusuario(usuarioLogadoService.pegarId());
     }
 
 

--- a/src/test/java/br/com/zup/projeto_final/Usuario/UsuarioControllerTest.java
+++ b/src/test/java/br/com/zup/projeto_final/Usuario/UsuarioControllerTest.java
@@ -8,6 +8,7 @@ import br.com.zup.projeto_final.customException.UsuarioJaCadastradoException;
 import br.com.zup.projeto_final.customException.UsuarioNaoEncontradoException;
 import br.com.zup.projeto_final.seguranca.UsuarioLoginService;
 import br.com.zup.projeto_final.seguranca.jwt.JWTComponent;
+import br.com.zup.projeto_final.usuarioLogado.UsuarioLogadoService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +36,8 @@ public class UsuarioControllerTest {
     private UsuarioLoginService usuarioLoginService;
     @MockBean
     private JWTComponent jwtComponent;
+    @MockBean
+    private UsuarioLogadoService usuarioLogadoService;
 
     @Autowired
     MockMvc mockMvc;
@@ -229,10 +232,11 @@ public class UsuarioControllerTest {
     @Test
     @WithMockUser("user@user.com")
     public void testarAtualizarUsuario() throws Exception {
+        Mockito.when(usuarioLogadoService.pegarId()).thenReturn("1");
         Mockito.when(usuarioService.atualizarUsuario(Mockito.anyString(), Mockito.any(Usuario.class))).thenReturn(usuario);
         String json = objectMapper.writeValueAsString(usuarioDTO);
 
-        ResultActions resultado = mockMvc.perform(MockMvcRequestBuilders.put("/usuarios/1")
+        ResultActions resultado = mockMvc.perform(MockMvcRequestBuilders.put("/usuarios")
                         .content(json).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().is(200));
 

--- a/src/test/java/br/com/zup/projeto_final/Usuario/UsuarioControllerTest.java
+++ b/src/test/java/br/com/zup/projeto_final/Usuario/UsuarioControllerTest.java
@@ -262,9 +262,10 @@ public class UsuarioControllerTest {
     @Test
     @WithMockUser("user@user.com")
     public void testarDeletarUsuario() throws Exception {
+        Mockito.when(usuarioLogadoService.pegarId()).thenReturn("1");
         Mockito.doNothing().when(usuarioService).deletarusuario(Mockito.anyString());
 
-        ResultActions resultado = mockMvc.perform(MockMvcRequestBuilders.delete("/usuarios/" + usuario.getId())
+        ResultActions resultado = mockMvc.perform(MockMvcRequestBuilders.delete("/usuarios")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().is(204));
 

--- a/src/test/java/br/com/zup/projeto_final/Usuario/UsuarioControllerTest.java
+++ b/src/test/java/br/com/zup/projeto_final/Usuario/UsuarioControllerTest.java
@@ -248,17 +248,14 @@ public class UsuarioControllerTest {
     //testar atualizar usuario que não existe
     @Test //TDD
     @WithMockUser("user@user.com")
-    public void testarAtualizarUsuarioNaoEncontrado() throws Exception {
-
-        Mockito.doThrow(UsuarioNaoEncontradoException.class).when(usuarioService)
-                .atualizarUsuario(Mockito.anyString(), Mockito.any(Usuario.class));
+    public void testarAtualizarUsuarioNaoPermitido() throws Exception {
 
         String json = objectMapper.writeValueAsString(usuarioDTO);
 
         ResultActions resultado = mockMvc.perform(MockMvcRequestBuilders
-                        .put("/usuarios/0").content(json)
+                        .put("/usuarios/1").content(json)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().is(404));
+                .andExpect(MockMvcResultMatchers.status().is(405));
 
     }
 


### PR DESCRIPTION
Nesse PR:

Atualizei os métodos AtualizarUsuario e DeletarUsuario para que o usuário não informe o ID que ele vai cadastrar, esse ID é fornecido pela aplicação através da UsuarioLogadoService. Isso impossibilita um usuário de modificar/excluir os dados de outro.
Após a atualização dos métodos, atualizei seus testes, fiz isso mockando a UsuarioLoginService e alterando a uri da requisição (antes era "/usuario/1", agora é só "/usuario".
Quanto ao método testarAtualizarUsuarioNaoEncontrado, eu o removi porque agora essa é uma realidade impossível de acontecer, e o substitui pelo método testarAtualizarUsuarioNaoPermitido, que testa se caso o usuario insira a URI inválida (usuarios/1 por exemplo) ele vai ser barrado.