### PR TITLE
Feature/aplicar regra de negocio para delecao de usuario

### DIFF
--- a/src/main/java/br/com/zup/projeto_final/Livro/Livro.java
+++ b/src/main/java/br/com/zup/projeto_final/Livro/Livro.java
@@ -4,6 +4,7 @@ import br.com.zup.projeto_final.Enun.Genero;
 import br.com.zup.projeto_final.Enun.Tags;
 import br.com.zup.projeto_final.Textos.comentario.Comentario;
 import br.com.zup.projeto_final.Textos.Review;
+import br.com.zup.projeto_final.Usuario.Usuario;
 import lombok.Data;
 
 import javax.persistence.*;
@@ -21,6 +22,8 @@ public class Livro {
     private String autor;
     private Genero genero;
     private Tags tags;
+    @ManyToOne
+    private Usuario quemCadastrou;
     @OneToOne (cascade = CascadeType.PERSIST)
     private Review review;
     @OneToMany

--- a/src/main/java/br/com/zup/projeto_final/Usuario/UsuarioService.java
+++ b/src/main/java/br/com/zup/projeto_final/Usuario/UsuarioService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -88,6 +89,10 @@ public class UsuarioService {
         List <Livro> livrosSemDono = usuario.getLivrosCadastrados();
         Optional <Usuario> usuarioDeletadoOptional = usuarioRepository.findByEmail("usuario_deletado@zupreaders.com");
         Usuario usuarioDeletado = usuarioDeletadoOptional.get();
+        if (usuarioDeletado.getLivrosCadastrados() == null){
+            usuarioDeletado.setLivrosCadastrados(new ArrayList<>());
+        }
+
         for (Livro referencia : livrosSemDono){
             usuarioDeletado.getLivrosCadastrados().add(referencia);
         }

--- a/src/main/java/br/com/zup/projeto_final/Usuario/UsuarioService.java
+++ b/src/main/java/br/com/zup/projeto_final/Usuario/UsuarioService.java
@@ -79,8 +79,18 @@ public class UsuarioService {
 
 
     public void deletarusuario(String id){
-        buscarUsuario(id);
+        Usuario usuarioQueEstaSendoDeletado = buscarUsuario(id);
+        substituirUsuarioParaUsuarioDeletado(usuarioQueEstaSendoDeletado);
         usuarioRepository.deleteById(id);
+    }
+
+    public void substituirUsuarioParaUsuarioDeletado(Usuario usuario){
+        List <Livro> livrosSemDono = usuario.getLivrosCadastrados();
+        Optional <Usuario> usuarioDeletadoOptional = usuarioRepository.findByEmail("usuario_deletado@zupreaders.com");
+        Usuario usuarioDeletado = usuarioDeletadoOptional.get();
+        for (Livro referencia : livrosSemDono){
+            usuarioDeletado.getLivrosCadastrados().add(referencia);
+        }
     }
 
 }

--- a/src/test/java/br/com/zup/projeto_final/Livro/LivroServiceTest.java
+++ b/src/test/java/br/com/zup/projeto_final/Livro/LivroServiceTest.java
@@ -66,7 +66,7 @@ public class LivroServiceTest {
         comentario = new Comentario();
         comentario.setQuemComentou(usuario);
         comentario.setId(1);
-        comentario.setIdLivro(1);
+        comentario.setLivro_id(1);
         comentario.setTexto("Algum comentário");
 
     }

--- a/src/test/java/br/com/zup/projeto_final/Usuario/UsuarioServiceTest.java
+++ b/src/test/java/br/com/zup/projeto_final/Usuario/UsuarioServiceTest.java
@@ -1,6 +1,9 @@
 package br.com.zup.projeto_final.Usuario;
 
 
+import br.com.zup.projeto_final.Enun.Genero;
+import br.com.zup.projeto_final.Enun.Tags;
+import br.com.zup.projeto_final.Livro.Livro;
 import br.com.zup.projeto_final.customException.UsuarioJaCadastradoException;
 import br.com.zup.projeto_final.customException.UsuarioNaoEncontradoException;
 import org.junit.jupiter.api.Assertions;
@@ -12,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -24,14 +28,39 @@ public class UsuarioServiceTest {
     UsuarioService usuarioService;
 
     private Usuario usuario;
+    private Usuario usuarioDeletado;
+    private List<Livro> livrosSemDono;
+    private Livro livro;
 
     @BeforeEach
     public void setup() {
+
+        livro = new Livro();
+        livro.setNome("Livro");
+        livro.setGenero(Genero.AVENTURA);
+        livro.setId(1);
+        livro.setLido(true);
+        livro.setTags(Tags.LEITURA_LEVE);
+        livro.setAutor("Autor");
+
+        livrosSemDono = new ArrayList<>();
+        livrosSemDono.add(livro);
+
         usuario = new Usuario();
         usuario.setId("1");
         usuario.setEmail("zupper@zup.com");
         usuario.setNome("Zupper");
         usuario.setSenha("aviao11");
+        usuario.setLivrosCadastrados(new ArrayList<>());
+        usuario.getLivrosCadastrados().add(livro);
+
+
+        usuarioDeletado = new Usuario();
+        usuarioDeletado.setId("2");
+        usuarioDeletado.setNome("USUARIO DELETADO");
+        usuarioDeletado.setEmail("usuario_deletado@zupreaders.com");
+        usuario.setSenha("usuario_deletado");
+
 
     }
 
@@ -91,14 +120,12 @@ public class UsuarioServiceTest {
     public void testarBuscarUsuario() {
         Mockito.when(usuarioRepository.findById(Mockito.anyString())).thenReturn(Optional.of(usuario));
         Usuario usuarioResposta = usuarioService.buscarUsuario(Mockito.anyString());
-
         Assertions.assertNotNull(usuarioResposta);
-
+        Assertions.assertEquals(Usuario.class, usuarioResposta.getClass());
+        Assertions.assertEquals(usuario.getId(), usuarioResposta.getId());
         Mockito.verify(usuarioRepository, Mockito.times(1)).findById(Mockito.anyString());
-
         Mockito.when(usuarioRepository.findById(Mockito.anyString())).thenReturn(Optional.empty());
         Assertions.assertThrows(UsuarioNaoEncontradoException.class, () -> usuarioService.buscarUsuario(Mockito.anyString()));
-
         Mockito.verify(usuarioRepository, Mockito.times(2)).findById(Mockito.anyString());
 
     }
@@ -157,9 +184,9 @@ public class UsuarioServiceTest {
     @Test
     public void testarDeletarUsuarioSucesso() {
         Mockito.when(usuarioRepository.findById(Mockito.anyString())).thenReturn(Optional.of(usuario));
+        Mockito.when(usuarioRepository.findByEmail(Mockito.anyString())).thenReturn(Optional.of(usuarioDeletado));
         Mockito.doNothing().when(usuarioRepository).deleteById(Mockito.anyString());
-
-        usuarioService.deletarusuario(Mockito.anyString());
+        usuarioService.deletarusuario(usuario.getId());
 
         Mockito.verify(usuarioRepository, Mockito.times(1)).deleteById(Mockito.anyString());
 


### PR DESCRIPTION
Neste PR:

Atualizei o método da service de deletarUsuario para quando um usuário for deletado, o sistema verifique se ele tem livros cadastrados, e caso tenha, esses livros ficam com o atributo quemCadastrou setado para USUARIO DELETADO.
Pra fazer isso criei um novo método responsável por isso.
O teste testarDeletarUsuario foi refatorado pra testar as mudanças que ocorreram no método 