### PR TITLE
Fix/curtida duplicada

### DIFF
--- a/src/main/java/br/com/zup/projeto_final/curtida/Curtida.java
+++ b/src/main/java/br/com/zup/projeto_final/curtida/Curtida.java
@@ -16,6 +16,7 @@ public class Curtida {
     private Long id_curtida;
     private Long id_recurso;
     private String id_usuario;
+    @Enumerated(EnumType.STRING)
     private Tipo tipo;
 
 }

--- a/src/main/java/br/com/zup/projeto_final/curtida/CurtidaRepository.java
+++ b/src/main/java/br/com/zup/projeto_final/curtida/CurtidaRepository.java
@@ -1,6 +1,11 @@
 package br.com.zup.projeto_final.curtida;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface CurtidaRepository extends CrudRepository<Curtida, Integer> {
+
+    @Query(value = "SELECT * FROM curtidas c WHERE c.id_usuario = ?1 AND c.id_recurso = ?2 AND c.tipo = ?3",
+            nativeQuery = true)
+    Curtida curtidaRepetida(String id_usuario, Long id_recurso, String tipo);
 }

--- a/src/main/java/br/com/zup/projeto_final/curtida/CurtidaService.java
+++ b/src/main/java/br/com/zup/projeto_final/curtida/CurtidaService.java
@@ -11,7 +11,16 @@ public class CurtidaService {
     CurtidaRepository curtidaRepository;
 
     public void salvarCurtida(Curtida curtida){
+        impedirCurtidaRepetida(curtida);
         curtidaRepository.save(curtida);
+    }
+
+    public void impedirCurtidaRepetida(Curtida curtida){
+        Curtida curtidaEncontrada = curtidaRepository.curtidaRepetida(curtida.getId_usuario(),
+                curtida.getId_recurso(), String.valueOf(curtida.getTipo()));
+        if (curtidaEncontrada != null){
+            throw new CurtidaRepetidaException("Este " + curtida.getTipo() + " já foi curtido por este usuário");
+        }
     }
 
 

--- a/src/test/java/br/com/zup/projeto_final/curtida/CurtidaServiceTest.java
+++ b/src/test/java/br/com/zup/projeto_final/curtida/CurtidaServiceTest.java
@@ -1,6 +1,9 @@
 package br.com.zup.projeto_final.curtida;
 
 import br.com.zup.projeto_final.Enun.Tipo;
+import br.com.zup.projeto_final.customException.CurtidaRepetidaException;
+import br.com.zup.projeto_final.customException.UsuarioNaoEncontradoException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -33,4 +36,13 @@ public class CurtidaServiceTest {
         curtidaService.salvarCurtida(curtida);
         Mockito.verify(curtidaRepository, Mockito.times(1)).save(curtida);
     }
+
+    @Test
+    public void testarImpedirCurtidaRepetidaCaminhoPositivo(){
+        Mockito.when(curtidaRepository.curtidaRepetida(Mockito.anyString(), Mockito.anyLong(), Mockito.anyString()))
+                .thenReturn(null);
+        curtidaService.impedirCurtidaRepetida(curtida);
+    }
+
+
 }

--- a/src/test/java/br/com/zup/projeto_final/curtida/CurtidaServiceTest.java
+++ b/src/test/java/br/com/zup/projeto_final/curtida/CurtidaServiceTest.java
@@ -44,5 +44,13 @@ public class CurtidaServiceTest {
         curtidaService.impedirCurtidaRepetida(curtida);
     }
 
-
+    @Test
+    public void testarImpedirCurtidaRepetidaCaminhoNegativo(){
+        Mockito.when(curtidaRepository.curtidaRepetida(Mockito.anyString(), Mockito.anyLong(), Mockito.anyString()))
+                .thenReturn(curtida);
+        CurtidaRepetidaException exception = Assertions.assertThrows(CurtidaRepetidaException.class, () ->{
+            curtidaService.salvarCurtida(curtida);
+        });
+        Assertions.assertEquals("Este COMENTARIO já foi curtido por este usuário", exception.getMessage());
+    }
 }


### PR DESCRIPTION
Neste PR:

Criei o método impedirCurtidaRepetida, que através de uma query de pesquisa, ele encontra no banco de dados se existe uma curtida que possua os mesmos atributos: id_usuario, id_recurso, tipo.
Caso exista, uma exceção é gerada. Do contrário, o cadastro da curtida segue normal.

Foram implementados os testes desse novo método.