### PR TITLE
Corrigir bug ao cadastrar comentário

### DIFF
--- a/src/main/java/br/com/zup/projeto_final/Textos/comentario/ComentariosService.java
+++ b/src/main/java/br/com/zup/projeto_final/Textos/comentario/ComentariosService.java
@@ -26,10 +26,11 @@ public class ComentariosService {
         if (usuario.isEmpty()){
             throw new UsuarioNaoEncontradoException("");
         }
+        comentarioRepository.save(comentario);
         livroService.atualizarComentariosDoLivro(comentario.getLivro_id(), comentario);
 
         comentario.setQuemComentou(usuario.get());
-        comentarioRepository.save(comentario);
+
     }
 
 

--- a/src/main/java/br/com/zup/projeto_final/Textos/comentario/dtos/ComentarioDTO.java
+++ b/src/main/java/br/com/zup/projeto_final/Textos/comentario/dtos/ComentarioDTO.java
@@ -6,6 +6,6 @@ import lombok.Data;
 public class ComentarioDTO {
 
     private String texto;
-    private int idLivro;
+    private int livro_id;
 
 }

--- a/src/test/java/br/com/zup/projeto_final/comentario/ComentarioControllerTest.java
+++ b/src/test/java/br/com/zup/projeto_final/comentario/ComentarioControllerTest.java
@@ -67,7 +67,7 @@ public class ComentarioControllerTest {
 
 
         comentarioDTO = new ComentarioDTO();
-        comentarioDTO.setIdLivro(1);
+        comentarioDTO.setLivro_id(1);
         comentarioDTO.setTexto("a");
 
         objectMapper = new ObjectMapper();


### PR DESCRIPTION
Corrigi um erro ao cadastrar o comentário.
É preciso salvar ele no banco de dados antes de adicioná-lo a lista de comentários de um livro.
Eu estava salvando depois e isso causava um bug.
Além disso, aproveitei e refatorei o nome do atributo id_livro.